### PR TITLE
GH-2 Document default tasks and configuration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,7 @@
 # The `.env` file is used by our front-end development tooling to personalize
 # the behavior of development tasks. If you wish to alter the way our toolchain
-# behaves during development, copy the contents of this file into a `.env` file.
+# behaves during development, copy the contents of this file into a `.env` file
+# wherever you installed Calliope (e.g. the theme's folder `web/themes/example`).
 
 # To lint SCSS files during development, uncomment the following line.
 # CALLIOPE_LINT_SCSS=true

--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,17 @@
+# The `.env` file is used by our front-end development tooling to personalize
+# the behavior of development tasks. If you wish to alter the way our toolchain
+# behaves during development, copy the contents of this file into a `.env` file.
+
+# To lint SCSS files during development, uncomment the following line.
+# CALLIOPE_LINT_SCSS=true
+
+# To lint JS files during development, uncomment the following line.
+# CALLIOPE_LINT_JS=true
+
+# To have Browsersync reverse proxy your local site, uncomment the following
+# line and set the URL you would like to reverse proxy.
+# CALLIOPE_REVERSE_PROXY_URL=https://myproject.lndo.site
+
+# Alternatively, if you would like to disable the reverse proxy altogether,
+# uncomment the following line:
+# CALLIOPE_REVERSE_PROXY_URL=null

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Now running `yarn build` will do the same thing as `yarn calliope build`. You ca
 
 # Configuration
 
-Calliope works without additional configuration but should you need to configure how any of the default tasks behave or add configuration for a custom task, you’ll be able to do so by creating a `calliope.config.js` file in the same directory as your project’s `package.json`. See the [`calliope.sample-config.js`] file in this repository for details on how to configure each individual task from your newly-created configuration file, or as a reference for creating your configuration object for a custom task.
+Calliope works without additional configuration. Should you need to configure how any of the default tasks behave or add configuration for a custom task, you’ll be able to do so by creating a `calliope.config.js` file in the same directory as your project’s `package.json`. See the [`calliope.sample-config.js`] file in this repository for details on how to configure each individual task from your newly-created configuration file, or as a reference for creating your configuration object for a custom task.
 
 # Available Commands
 
@@ -86,7 +86,7 @@ The command above would run the `scripts` task once by itself.
 
 # Default Tasks
 
-Calliope ships with a few basic tasks that most projects will need. This section provides an overview of these tasks and what they accomplish. For details of the configuration options available for each of the following tasks, see the [`calliope.sample-config.js`] file in this project’s repository.
+Calliope ships with a few basic tasks that most projects will need. This section provides an overview of these tasks and what they accomplish. For details on the configuration options available for each of the following tasks, see the [`calliope.sample-config.js`] file in this project’s repository.
 
 ## Pipelines
 
@@ -94,7 +94,7 @@ Your project’s build is defined by its pipeline tasks. These tasks are concern
 
 ### `fonts` - Move Font Files
 
-The `fonts` task merely moves font files from your source directory to the destination directory withour any additional processing.
+The `fonts` task merely moves font files from your source directory to the destination directory without any additional processing.
 
 **`fonts` is disabled by default, but can be easily enabled by adding a configuration object for it in your project’s `calliope.config.js` file. See [`calliope.sample-config.js`] for configuration details.**
 
@@ -231,7 +231,7 @@ const myCustomVar = process.env.CALLIOPE_MY_CUSTOM_VAR || 'some less fun fallbac
 
 See the `pipelines.scripts` and `pipelines.styles` objects in the `config/defaults.js` file in this project for other examples of how we currently use environment variables.
 
-It’s important to note that these personalization options should always be optional and there should always be a fallback in your configuration. You should also document any new environment variables in the Development Settings section of your project’s README for ease of reference, and add sample variable definitions in your project’s [`.env.sample`] file.
+It’s important to note that these personalization options should always be optional and there should always be a fallback in your configuration. You should also document any new environment variables in the Development Settings section of your project’s README for ease of reference and add sample variable definitions in your project’s [`.env.sample`] file.
 
 [Available Commands]: #available-commands
 [`calliope.sample-config.js`]: https://github.com/ChromaticHQ/calliope/blob/main/calliope.sample-config.js

--- a/README.md
+++ b/README.md
@@ -69,7 +69,72 @@ Now running `yarn build` will do the same thing as `yarn calliope build`. You ca
 
 # Configuration
 
-Calliope works without additional configuration but should you need to configure how any of the default tasks behave, first create a `calliope.config.js` file in the same directory as your project’s `package.json`. See the `calliope.sample-config.js` file in this repository for details.
+Calliope works without additional configuration but should you need to configure how any of the default tasks behave or add configuration for a custom task, you’ll be able to do so by creating a `calliope.config.js` file in the same directory as your project’s `package.json`. See the [`calliope.sample-config.js`] file in this repository for details on how to configure each individual task from your newly-created configuration file, or as a reference for creating your configuration object for a custom task.
+
+# Available Commands
+
+For the most part, you will be interacting with two commands: `build` and `start`. The `build` command runs all of the tasks defined as pipelines (see [Pipelines] below). The `start` command will run the `build` command, watch for changes in the project’s source files, and re-run the appropriate tasks when any changes are detected. In addition to watching for changes, the `start` command will also run any daemons available in your project.
+
+In addition to these built-in commands, any individual task can be invoked as a standalone command via Calliope’s CLI. Once your `package.json` has been set up according to the [Installation & Usage] section, you can run any task from the command line like so:
+
+```shell
+yarn calliope scripts
+```
+
+The command above would run the `scripts` task once by itself.
+
+
+# Default Tasks
+
+Calliope ships with a few basic tasks that most projects will need. This section provides an overview of these tasks and what they accomplish. For details of the configuration options available for each of the following tasks, see the [`calliope.sample-config.js`] file in this project’s repository.
+
+## Pipelines
+
+Your project’s build is defined by its pipeline tasks. These tasks are concerned with processing your project’s static assets (JS, CSS, images, etc) and are run every time you run the `build` or `start` commands.
+
+### `fonts` - Move Font Files
+
+The `fonts` task merely moves font files from your source directory to the destination directory withour any additional processing.
+
+**`fonts` is disabled by default, but can be easily enabled by adding a configuration object for it in your project’s `calliope.config.js` file. See [`calliope.sample-config.js`] for configuration details.**
+
+### `images` - Optimize Images
+
+The `images` moves image files from the source directory to the destination directory. It also provides simple image optimization for SVGs via [`gulp-imagemin`](https://npmjs.com/package/gulp-imagemin).
+
+**`images` is disabled by default, but can be easily enabled by adding a configuration object for it in your project’s `calliope.config.js` file. See [`calliope.sample-config.js`] for configuration details.**
+
+### `scripts` - Optimize JavaScript
+
+The `scripts` task handles operations related to JavaScript processing and optimization. It provides linting, uglification/compression (via [`terser`](https://npmjs.com/package/terser)), and concatenation. All of these operations are configurable to some degree.
+
+By default, this task does not lint JS files, but linting can be enabled via an `.env` file. See [Developer Personalization] for details.
+
+### `styles` - Pre-process Stylesheets
+
+The `styles` task generates CSS from your project’s `.scss` files using [`node-sass`](https://npmjs.com/package/node-sass). It includes a few affordances, such as [`gulp-sass-glob`](https://npmjs.com/package/gulp-sass-glob), [`gulp-autoprefixer`](https://www.npmjs.com/package/gulp-autoprefixer), and [`gulp-clean-css`](https://www.npmjs.com/package/gulp-clean-css). This task generates both minified and expanded (i.e. not minified) CSS stylesheets. Minified stylesheets will be named after your SCSS files, and expanded stylesheets will have the suffix `-expanded` attached to the filename. So if your stylesheet is named `main.scss`, Calliope will produce two files: `main.css` and `main-expanded.css`.
+
+By default, this task does not lint SCSS files, but linting can be enabled via an `.env` file. See [Developer Personalization] for details.
+
+## Daemons
+
+Daemons are tasks that run alongside your watched tasks when you use the `start` command. They are typically servers designed to enhance or otherwise facilitate the development experience without necessarily impacting the outcome of your build.
+
+### `browsersync` - Reverse Proxy
+
+The `browsersync` task reverse proxies your project’s local URL, so that it may be accessed at <https://localhost:3000>. Using this reverse proxy during development saves time and effort by dynamically refreshing styles when styles change or auto-refreshing the page when JS or template files change.
+
+## Generic Tasks
+
+Generic tasks are tasks that are not part of the build and are not run alongside your watched tasks, but are nevertheless invoked independently throughout the development workflow in one way or another.
+
+### `lint` - Lint JS and SCSS
+
+The `lint` tasks uses [`gulp-eslint-new`](https://npmjs.com/package/gulp-eslint-new) and [`gulp-stylelint`](https://npmjs.com/package/gulp-stylelint) to lint your project’s JS and SCSS (respectively). It uses the `src` and (optional) `watch` settings of the `scripts` and `styles` configuration to determine which files should be linted, and relies on your project’s `.eslintrc.yml` and `.stylelintrc.yml` files to define the rules with which to lint your source files.
+
+# Developer Personalization
+
+In addition to the configuration options available in your project’s `calliope.config.js`, individual developers may modify parts of the tooling behavior according to their personal preferences. Developers may opt into JS and SCSS linting, and modify the reverse proxy’s URL (or opt out of reverse proxying altogether) by creating a `.env` file in their project and setting variables according to their needs. See the [`.env.sample`] file in this project’s repo for reference.
 
 # Customization
 
@@ -80,7 +145,7 @@ Calliope will serve the needs of most of our projects out of the box, but if you
 Calliope is just a fancy wrapper around Gulp, so all tasks that you may need to create will be just standard Gulp tasks. However, there are three different types of tasks within Calliope, some of which get special treatment.
 
 1. **Pipelines:** These are typically tasks that process static assets, e.g. compiling styles, compressing JavaScript, processing images, moving fonts around, etc. If your custom task or override is intended to be run as part of each build, it goes in `calliope/pipelines/`. In addition to creating custom pipelines, Calliope supports overriding its default pipelines if your project requires this. See [Overriding Default Pipelines] below for details.
-1. **Daemons:** Daemons are long-running processes that you want Calliope to run _alongside_ any watched tasks. Anytime you run `yarn calliope start`, Calliope will not only build assets and start watching for changes, but also run any daemons that may be available. If you need to run a service during development (a component library server, an API stubs server, etc.), it belongs in `calliope/daemons/`. While you may create custom daemons to run in parallel to build and watch tasks during development, the default reverse proxy daemon may not be overridden at this time.
+1. **Daemons:** Daemons are long-running processes that you want Calliope to run _alongside_ any watched tasks. Anytime you run `yarn calliope start`, Calliope will not only build assets and start watching for changes, but also run any daemons that may be available. If you need to run a service during development (a component library server, an API stubs server, etc.), it belongs in `calliope/daemons/`. While you may create custom daemons to run in parallel to build and watched tasks during development, the default reverse proxy daemon may not be overridden at this time.
 1. **Tasks:** These are generic tasks that may be used as needed. They are standard Gulp taks that are only run when you explicitly invoke them in the command line. e.g. if you have a `calliope/tasks/build-patterns.js` file in your project, you can use `yarn calliope build-patterns` to run it. You can create as many custom generic tasks as your project needs, but existing ones are not currently overrideable.
 
 ## Overriding Default Pipelines
@@ -166,6 +231,13 @@ const myCustomVar = process.env.CALLIOPE_MY_CUSTOM_VAR || 'some less fun fallbac
 
 See the `pipelines.scripts` and `pipelines.styles` objects in the `config/defaults.js` file in this project for other examples of how we currently use environment variables.
 
-It’s important to note that these personalization options should always be optional and there should always be a fallback in your configuration. You should also document any new environment variables in the Development Settings section of your project’s README for ease of reference, and add sample variable definitions in your project’s `.env.sample` file.
+It’s important to note that these personalization options should always be optional and there should always be a fallback in your configuration. You should also document any new environment variables in the Development Settings section of your project’s README for ease of reference, and add sample variable definitions in your project’s [`.env.sample`] file.
 
+[Available Commands]: #available-commands
+[`calliope.sample-config.js`]: https://github.com/ChromaticHQ/calliope/blob/main/calliope.sample-config.js
+[Daemons]: #daemons
+[Developer Personalization]: #developer-personalization
+[`.env.sample`]: https://github.com/ChromaticHQ/calliope/blob/main/.env.sample
 [Overriding Default Pipelines]: #overriding-default-pipelines
+[Pipelines]: #pipelines
+[Generic Tasks]: #generic-tasks

--- a/calliope.sample-config.js
+++ b/calliope.sample-config.js
@@ -34,7 +34,8 @@ exports.pipelines = {
      * may be a path to a single file or a glob matching one or more files, or
      * an array of said strings.
      *
-     * Uncomment the next few lines and edit them as necessary. */
+     * Uncomment the next few lines and edit them as necessary.
+     */
     // src: [
     //   `${ paths.SRC }/fonts/**/*`,
     // ],
@@ -44,7 +45,8 @@ exports.pipelines = {
      *
      * The directory to which font files will be moved.
      *
-     * Uncomment the next line and edit it as necessary. */
+     * Uncomment the next line and edit it as necessary.
+     */
     // dest: `${ paths.DEST }/fonts`,
   },
   images: {
@@ -55,7 +57,8 @@ exports.pipelines = {
      * may be a path to a single file or a glob matching one or more files, or
      * an array of said strings.
      *
-     * Uncomment the next few lines and edit them as necessary. */
+     * Uncomment the next few lines and edit them as necessary.
+     */
     // src: [
     //   `${ paths.SRC }/images/**/*`,
     // ],
@@ -65,7 +68,8 @@ exports.pipelines = {
      *
      * The directory to which processed image files will be saved.
      *
-     * Uncomment the next line and edit it as necessary. */
+     * Uncomment the next line and edit it as necessary.
+     */
     dest: `${ paths.DEST }/images`,
   },
   scripts: {
@@ -79,7 +83,8 @@ exports.pipelines = {
      * files, instead processing and saving each one to the build directory
      * individually.
      *
-     * Uncomment the next line to enable bundling. */
+     * Uncomment the next line to enable bundling.
+     */
     // bundle: true,
 
     /**
@@ -90,7 +95,8 @@ exports.pipelines = {
      * JavaScript files. If set to `false`, your JavaScript will not be
      * compressed or uglified.
      *
-     * Uncomment the next line to disable compression. */
+     * Uncomment the next line to disable compression.
+     */
     // compress: false,
 
     /**
@@ -104,7 +110,8 @@ exports.pipelines = {
      * It is highly recommended that this be kept as-is, since it’s important
      * for developers to be able to configure their development environment as
      * they wish. That said, if your project needs to change this value,
-     * uncomment the next line and edit it as needed. */
+     * uncomment the next line and edit it as needed.
+     */
     // lint: env.CALLIOPE_LINT_JS === 'true',
 
     /**
@@ -114,7 +121,8 @@ exports.pipelines = {
      * source. It may be a path to a single file or a glob matching one or more
      * files, or an array of said strings.
      *
-     * Uncomment the next few lines and edit them as necessary. */
+     * Uncomment the next few lines and edit them as necessary.
+     */
     // src: [
     //   `${ paths.SRC }/scripts/**/*.js`,
     //   `${ paths.SRC }/components/**/*.js`,
@@ -126,7 +134,8 @@ exports.pipelines = {
      *
      * The directory to which generated JavaScript files will be saved.
      *
-     * Uncomment the next line and edit it as necessary. */
+     * Uncomment the next line and edit it as necessary.
+     */
     // dest: `${ paths.DEST }/scripts`,
   },
   styles: {
@@ -141,7 +150,8 @@ exports.pipelines = {
      * It is highly recommended that this be kept as-is, since it’s important
      * for developers to be able to configure their development environment as
      * they wish. That said, if your project needs to change this value,
-     * uncomment the next line and edit it as needed. */
+     * uncomment the next line and edit it as needed.
+     */
     // lint: env.CALLIOPE_LINT_SCSS === 'true',
 
     /**
@@ -151,7 +161,8 @@ exports.pipelines = {
      * may be a path to a single file or a glob matching one or more files, or
      * an array of said strings.
      *
-     * Uncomment the next few lines and edit them as necessary. */
+     * Uncomment the next few lines and edit them as necessary.
+     */
     // src: [
     //   `${ paths.SRC }/styles/**/*.scss`,
     // ],
@@ -167,7 +178,8 @@ exports.pipelines = {
      * task, but not necessarily processed individually themselves (e.g.
      * stylesheet partials).
      *
-     * Uncomment the next few lines and edit them as necessary. */
+     * Uncomment the next few lines and edit them as necessary.
+     */
     // watch: [
     //   `${ paths.SRC }/components/**/*.scss`,
     // ],
@@ -176,7 +188,8 @@ exports.pipelines = {
      * dest - String
      *
      * The directory to which generated CSS files will be saved.
-     * Uncomment the next line and edit it as necessary. */
+     * Uncomment the next line and edit it as necessary.
+     */
     // dest: `${ paths.DEST }/styles`,
   },
 };
@@ -189,7 +202,8 @@ exports.daemons = {
      * An absolute URL representing a development environment of your project.
      * Browsersync will reverse proxy this URL during development.
      *
-     * Uncomment the next line and edit it as necessary. */
+     * Uncomment the next line and edit it as necessary.
+     */
     // proxy: 'http://myproject.lndo.site',
   },
 };

--- a/calliope.sample-config.js
+++ b/calliope.sample-config.js
@@ -1,62 +1,195 @@
 /**
  * @file
- * Configuration objects used in Gulp tasks.
+ * Configuration objects used by Calliope.
  */
 
-// Paths used throughout our configuration objects.
+/**
+ * paths Object
+ *
+ * Paths used throughout the sample configuration values below. This has no
+ * significance beyond this file; it is merely here to avoid duplication of
+ * source and destination paths in the configuration values used below.
+ */
 const paths = {
-  // source
+  // Source.
   SRC: 'src',
-  // destination
+  // Destination.
   DEST: 'build',
-  // settings
-  CONF: 'toolchain',
-}
+};
 
-// Export a register of assets pipelines: the `build` and `watch` tasks use
-// this object to programmatically run each pipeline. If it aint here, it ain’t
-// getting built! Destination directories are relative to theme root.
+/**
+ * pipelines Object
+ *
+ * A register of assets pipelines: the `build` and `watch` tasks use this
+ * object to programmatically run each pipeline. If it ain’t here, it ain’t
+ * getting built! Destination directories are relative to the current working
+ * directory.
+ */
 exports.pipelines = {
   fonts: {
-    src: [
-      `${ paths.SRC }/fonts/**/*`,
-    ],
-    dest: `${ paths.DEST }/fonts`,
+    /**
+     * src - String or Array of Strings
+     *
+     * A value representing one or more font files to be used as a source. It
+     * may be a path to a single file or a glob matching one or more files, or
+     * an array of said strings.
+     *
+     * Uncomment the next few lines and edit them as necessary. */
+    // src: [
+    //   `${ paths.SRC }/fonts/**/*`,
+    // ],
+
+    /**
+     * dest - String
+     *
+     * The directory to which font files will be moved.
+     *
+     * Uncomment the next line and edit it as necessary. */
+    // dest: `${ paths.DEST }/fonts`,
   },
   images: {
-    src: [
-      `${ paths.SRC }/images/**/*`,
-    ],
+    /**
+     * src - String or Array of Strings
+     *
+     * A value representing one or more image files to be used as a source. It
+     * may be a path to a single file or a glob matching one or more files, or
+     * an array of said strings.
+     *
+     * Uncomment the next few lines and edit them as necessary. */
+    // src: [
+    //   `${ paths.SRC }/images/**/*`,
+    // ],
+
+    /**
+     * dest - String
+     *
+     * The directory to which processed image files will be saved.
+     *
+     * Uncomment the next line and edit it as necessary. */
     dest: `${ paths.DEST }/images`,
   },
   scripts: {
-    bundle: false,
-    compress: true,
-    src: [
-      `${ paths.SRC }/scripts/**/*.js`,
-      `${ paths.SRC }/components/**/*.js`,
-      `!${ paths.SRC }/components/**/*.config.js`,
-    ],
-    dest: `${ paths.DEST }/scripts`,
+    /**
+     * bundle - String or falsy value
+     *
+     * If set to a string (e.g. 'main.js'), Calliope will concatenate all JS
+     * files into a single JS file using that string for the filename. Files
+     * are concatenated in the order in which they are processed. If this
+     * option is not set, Calliope will default to `false` and not concatenate
+     * files, instead processing and saving each one to the build directory
+     * individually.
+     *
+     * Uncomment the next line to enable bundling. */
+    // bundle: true,
+
+    /**
+     * compress - Boolean
+     *
+     * Whether the generated JavaScript should be uglified. Calliope uses
+     * terser (https://www.npmjs.com/package/terser) to compress and uglify
+     * JavaScript files. If set to `false`, your JavaScript will not be
+     * compressed or uglified.
+     *
+     * Uncomment the next line to disable compression. */
+    // compress: false,
+
+    /**
+     * lint - Boolean
+     *
+     * Whether to lint JavaScript files during build. If true, Calliope will
+     * lint your JavaScript as part of the `scripts` task. This configuration
+     * has no effect on the standalone `lint` task; that task always lints
+     * JavaScript regardless of this setting.
+     *
+     * It is highly recommended that this be kept as-is, since it’s important
+     * for developers to be able to configure their development environment as
+     * they wish. That said, if your project needs to change this value,
+     * uncomment the next line and edit it as needed. */
+    // lint: env.CALLIOPE_LINT_JS === 'true',
+
+    /**
+     * src - String or Array of Strings
+     *
+     * A value representing one or more JavaScript files to be used as a
+     * source. It may be a path to a single file or a glob matching one or more
+     * files, or an array of said strings.
+     *
+     * Uncomment the next few lines and edit them as necessary. */
+    // src: [
+    //   `${ paths.SRC }/scripts/**/*.js`,
+    //   `${ paths.SRC }/components/**/*.js`,
+    //   `!${ paths.SRC }/components/**/*.config.js`,
+    // ],
+
+    /**
+     * dest - String
+     *
+     * The directory to which generated JavaScript files will be saved.
+     *
+     * Uncomment the next line and edit it as necessary. */
+    // dest: `${ paths.DEST }/scripts`,
   },
   styles: {
-    src: [
-      `${ paths.SRC }/styles/**/*.scss`,
-    ],
-    // Any pipeline task can have a `watch` key whose value is an array of
-    // paths or globs that will be watched in addition to the pipeline’s `src`.
-    // This is particularly useful with Sass-based stylesheets, where we only
-    // source a handful of files, but we need to watch for changes in many
-    // other files.
-    watch: [
-      `${ paths.SRC }/components/**/*.scss`,
-    ],
-    dest: `${ paths.DEST }/styles`,
+    /**
+     * lint - Boolean
+     *
+     * Whether to lint SCSS files during build. If true, Calliope will lint
+     * your SCSS as part of the `styles` task. This configuration has no effect
+     * on the standalone `lint` task; that task always lints SCSS regardless of
+     * this setting.
+     *
+     * It is highly recommended that this be kept as-is, since it’s important
+     * for developers to be able to configure their development environment as
+     * they wish. That said, if your project needs to change this value,
+     * uncomment the next line and edit it as needed. */
+    // lint: env.CALLIOPE_LINT_SCSS === 'true',
+
+    /**
+     * src - String or Array of Strings
+     *
+     * A value representing one or more SCSS files to be used as a source. It
+     * may be a path to a single file or a glob matching one or more files, or
+     * an array of said strings.
+     *
+     * Uncomment the next few lines and edit them as necessary. */
+    // src: [
+    //   `${ paths.SRC }/styles/**/*.scss`,
+    // ],
+
+    /**
+     * watch - String or Array of Strings
+     *
+     * A value representing one or more SCSS files to be watched during
+     * development. It may be a path to a single file or a glob matching one or
+     * more files, or an array of said strings.
+     *
+     * Use this option to declare files that may need to trigger a watched
+     * task, but not necessarily processed individually themselves (e.g.
+     * stylesheet partials).
+     *
+     * Uncomment the next few lines and edit them as necessary. */
+    // watch: [
+    //   `${ paths.SRC }/components/**/*.scss`,
+    // ],
+
+    /**
+     * dest - String
+     *
+     * The directory to which generated CSS files will be saved.
+     * Uncomment the next line and edit it as necessary. */
+    // dest: `${ paths.DEST }/styles`,
   },
 };
 
 exports.daemons = {
   browsersync: {
-    proxy: 'http://myproject.lndo.site',
+    /**
+     * proxy - String
+     *
+     * An absolute URL representing a development environment of your project.
+     * Browsersync will reverse proxy this URL during development.
+     *
+     * Uncomment the next line and edit it as necessary. */
+    // proxy: 'http://myproject.lndo.site',
   },
 };


### PR DESCRIPTION
## Description

This PR updates the README at the root of this project and `calliope.sample-config.js` files to better document the available tasks and their configuration. It also creates an `.env.sample` file to serve as a reference for developers looking to personalize the development experience.

## Motivation / Context

The README does not sufficiently document the default tasks and configuration available with Calliope.

Closes GH-2.

## Testing Instructions / How This Has Been Tested

Proofreading the changes in this PR should suffice.

## Screenshots

n/a

## Documentation

This is it!