### PR TITLE
Windows friendly spawn gulp

### DIFF
--- a/gulp.js
+++ b/gulp.js
@@ -2,7 +2,7 @@ const path = require('path');
 const spawn = require('child_process').spawn;
 
 function gulp({ command, args }) {
-  spawn('gulp', [
+  spawn((process.platform === 'win32' ? 'gulp.cmd' : 'gulp') , [
     '--gulpfile',
     path.resolve(__dirname, 'gulpfile.js'),
     '--cwd',


### PR DESCRIPTION
## Description
Doing a `composer robo theme:build default` fails on a Windows environment.
See Issue [#14](https://github.com/ChromaticHQ/calliope/issues/14) for stack trace.

## Motivation / Context
The `spawn`ing of `gulp` fails on a Windows environment.
See Issue [#14](https://github.com/ChromaticHQ/calliope/issues/14).

## Testing Instructions / How This Has Been Tested
This PR checks if the OS it's running on is Windows, if so it spawn gulp using the Windows-friendly `gulp.cmd` to do so, otherwise it keeps using the existing `gulp` command.

Tested by:
(As I've only used `calliope` on `chromatichq`, the below tests are done in that project. I'm pretty sure the change in this PR will be applicable to all projects that use `calliope` building on a Windows machine)

- In `web/themes/chromatic/package.json` swapped out `"@chromatichq/calliope": "^1.1.1",` for `"@chromatichq/calliope": "github:ChromaticHQ/calliope#1f6263fcc52f9ccfaf1fb6e075dd7eaf5706c16c",`, to use the code in this PR.
- Did a `composer robo theme:build default`
- Output: 
```
$ composer robo theme:build default
> Composer\Config::disableProcessTimeout
> robo --ansi theme:build default

theme build
===========

building theme at web/themes/chromatic
--------------------------------------

 [Exec] Running yarn build in web/themes/chromatic
yarn run v1.22.17
$ yarn calliope build
$ yarn install && calliope build
[1/4] Resolving packages...
success Already up-to-date.
$ symdeps



[13:52:49] ✓ Project config found!
[13:52:49]     Using file D:\htdocs\chromatichq.com\web\themes\chromatic\calliope.config.js.
[13:52:49] - No personalization options detected via .env file.
[13:52:49] ✓ Custom daemons found!
[13:52:49]     The following custom Gulp tasks will run alongside watch tasks:
[13:52:49]       - fractal
[13:52:52] ✓ Custom pipelines found!
[13:52:52]     The following custom or override Gulp tasks will run as part of your build:
[13:52:52]       - scripts
[13:52:52] ✓ Custom tasks found!
[13:52:52]     The following custom Gulp tasks are available:
[13:52:52]       - patterns
[13:52:52]       - preview
[13:53:06] Using gulpfile D:\htdocs\chromatichq.com\web\themes\chromatic\node_modules\@chromatichq\calliope\gulpfile.js
[13:53:06] Starting 'build'...
[13:53:06] Starting 'clean'...
[13:53:07] Finished 'clean' after 307 ms
[13:53:07] Starting 'fonts'...
[13:53:07] Starting 'images'...
[13:53:07] Starting 'styles'...
[13:53:07] Starting 'discreteScripts'...
[13:53:07] Starting 'bundledScripts'...
[13:53:09] Finished 'fonts' after 2.27 s
[13:53:10] Finished 'bundledScripts' after 3.3 s
[13:53:10] Finished 'discreteScripts' after 3.42 s
[13:53:38] Finished 'styles' after 32 s
[13:54:01] gulp-imagemin: Minified 65 images (saved 376 kB - 29.6%)
[13:54:01] Finished 'images' after 54 s
[13:54:01] Finished 'build' after 55 s
Done in 81.59s.
 [Exec] Done in 01:22

```
- Saw rainbows and unicorns appear.

## Screenshots
Screenshot without changes in this PR:
![image](https://user-images.githubusercontent.com/18569707/158183136-a745fd35-f51f-4a48-8219-55902dfdfcc3.png)

Screenshot using the changes in this PR:
![image](https://user-images.githubusercontent.com/18569707/158181370-3666dc6b-023d-404c-8295-eb34f30d794a.png)

## Documentation
None that I'm aware of.
