### PR TITLE
GH-18 Use registered Gulp task instead of requiring task file

### DIFF
--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -5,7 +5,7 @@
  */
 
 const gulp = require('gulp');
-const { series, task, watch } = require('gulp');
+const { series, watch } = require('gulp');
 
 const browsersync = require('./browsersync');
 const build = require('./build');
@@ -35,7 +35,7 @@ function watchSource(done) {
     if (pipelines[name].watch) {
       watchFiles = [...watchFiles, ...pipelines[name].watch];
     }
-    watch(watchFiles, { usePolling: true }, task(name));
+    watch(watchFiles, { usePolling: true }, gulp.task(name));
   });
   done();
 }

--- a/tasks/watch.js
+++ b/tasks/watch.js
@@ -5,7 +5,7 @@
  */
 
 const gulp = require('gulp');
-const { series, watch } = require('gulp');
+const { series, task, watch } = require('gulp');
 
 const browsersync = require('./browsersync');
 const build = require('./build');
@@ -35,7 +35,7 @@ function watchSource(done) {
     if (pipelines[name].watch) {
       watchFiles = [...watchFiles, ...pipelines[name].watch];
     }
-    watch(watchFiles, { usePolling: true }, require(`./${name}`));
+    watch(watchFiles, { usePolling: true }, task(name));
   });
   done();
 }


### PR DESCRIPTION
## Description

This PR updates Calliope’s internal `watch` task to use whatever task is currently registered with Gulp with a given name, instead of attempting to require a file with that name.

## Motivation / Context

The current strategy assumes that the task being processed is defined within Calliope itself, which is not always the case. In the case of a custom pipeline defined in a downstream project, the `start` command fails catastrophically. Arguably worse, in the case of a pipeline task override, the process simply picks up Calliope’s local task and uses that to generate files instead of the downstream project’s override.

## Testing Instructions / How This Has Been Tested

Two options here:
1. Trust me and the screenshots below.
2. Trust me, yet still check this yourself locally.

If you’re still reading: congratulations! Here’s what you need to do:

1. Clone this branch locally.
2. Run `yarn link` from the root of this repo.
3. Clone the [`chromatichq-eleventy`](/chromatichq/chromatichq-eleventy) repo.
4. From `chromatichq-eleventy`, run:
    1. `yarn install`
    2. `yarn start` - Confirm you see the error shown in the screenshots below (or the ticket).
    3. `yarn link @chromatichq/calliope`
    4. `yarn start` - Confirm you no longer see the error.
    5. `yarn unlink @chromatichq/calliope && yarn install` - This is just to make sure you don’t forget to unlink it later.

## Screenshots

|The problem|The fix|
|---|---|
|![image](https://user-images.githubusercontent.com/439649/158461533-724ef5b1-de84-4de8-8a27-56ab6c64489a.png)|![image](https://user-images.githubusercontent.com/439649/158461922-f6d7082d-6240-4976-9aa5-b6b026c25175.png)|
|Notice in the stack trace that Calliope’s internal `watch` appears to be trying to load an `./eleventy` file relative to itself.|No errors! This is with my local (and fixed!) Calliope linked via `yarn link @chromatichq/calliope`.|

## Documentation

n/a