### PR TITLE
GH-20 Ignore empty fonts and images task config

### DIFF
--- a/config/downstream.js
+++ b/config/downstream.js
@@ -21,6 +21,14 @@ function getDownstream(report) {
     daemons = downstream.daemons || daemons;
     pipelines = downstream.pipelines || pipelines;
     plugins = downstream.plugins || plugins;
+
+    // Consider `fonts` and `images` null if they are empty objects.
+    if (pipelines.fonts && Object.keys(pipelines.fonts).length === 0) {
+      pipelines.fonts = null;
+    }
+    if (pipelines.images && Object.keys(pipelines.images).length === 0) {
+      pipelines.images = null;
+    }
   } catch (error) {
     if (error.code !== 'MODULE_NOT_FOUND') throw error;
     if (report) log.info(chalk.cyan('- No calliope.config.js file found. Going with the defaults.'));


### PR DESCRIPTION
## Description

This PR ignores the downstream `fonts` and `images` config if they are empty objects.

## Motivation / Context

The `fonts` and `images` tasks are the only pipeline tasks that we do not run by default. Since including an empty object for these two tasks makes the boilerplate `calliope.config.js` file easier to read, we need to make an exception in our logic so that if downstream configuration includes empty objects for either of these two tasks, they are ignored.

Closes GH-20.

## Testing Instructions / How This Has Been Tested

I fixed the issue locally and tested it with a modified version of the [`chromatichq-eleventy`](/chromatichq/chromatichq-eleventy) repo that has the boilerplate config. See screenshots below.

## Screenshots

|The problem|The fix|
|---|---|
|![image](https://user-images.githubusercontent.com/439649/158470389-1c4be523-6177-423c-8837-8c5a7c865ec5.png)|![image](https://user-images.githubusercontent.com/439649/158470478-87ccf422-fe37-4e67-95df-79fe47258030.png)|

## Documentation

I added a comment above the logic in question explaining what it does.