### PR TITLE
Expose Sass compilation errors by default

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -9,7 +9,7 @@ const log = require('fancy-log');
 
 const defaults = require('./defaults');
 
-const { env } = process;
+const { argv, env } = process;
 
 function config(report) {
   // Load downstream configuration.
@@ -55,8 +55,10 @@ function config(report) {
     tasks: require('./tasks')(report),
   };
 
+  const ignoreErrors = argv.includes('--ignore-errors');
+
   return {
-    custom, daemons, pipelines, plugins,
+    custom, daemons, ignoreErrors, pipelines, plugins,
   };
 }
 

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,5 +1,5 @@
 {
-  "exec": "calliope watch --omit-setup-report",
+  "exec": "calliope watch --omit-setup-report --ignore-errors",
   "watch": [
     ".browserslistrc",
     ".env",

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -23,7 +23,11 @@ function styles() {
   return src(intake, { sourcemaps: true })
     .pipe(gulpIf(config.pipelines.styles.lint, stylelint(config.plugins.stylelint)))
     .pipe(sassGlob())
-    .pipe(sass(config.plugins.sass).on('error', function (error) {
+    .pipe(sass(config.plugins.sass).on('error', function handleSassError(error) {
+      // gulp-sass’s `logError` method does not adequately cause errors to get
+      // thrown, so we need to exit the process ourselves unless errors are
+      // ignored. Note that errors are only ignored while in the development
+      // start command.
       sass.logError.call(this, error);
       if (!config.ignoreErrors) process.exit(1);
     }))

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -23,7 +23,10 @@ function styles() {
   return src(intake, { sourcemaps: true })
     .pipe(gulpIf(config.pipelines.styles.lint, stylelint(config.plugins.stylelint)))
     .pipe(sassGlob())
-    .pipe(sass(config.plugins.sass).on('error', sass.logError))
+    .pipe(sass(config.plugins.sass).on('error', function (error) {
+      sass.logError.call(this, error);
+      if (!config.ignoreErrors) process.exit(1);
+    }))
     .pipe(autoprefixer())
     .pipe(rename((path) => path.basename += '-expanded'))
     .pipe(dest(output))


### PR DESCRIPTION
## Description

This PR updates the `styles` task to remove a regression that was causing it to catch Sass compilation errors and, therefore, fail silently.

## Motivation / Context

Discovered while attempting to test `styles` task for #22.

## Testing Instructions / How This Has Been Tested

Tested locally during a pairing session with @michelegrace.

## Screenshots

Sass compilation error causes the process to exit with a thrown error on `yarn build`:
![image](https://user-images.githubusercontent.com/439649/159764436-b4a38088-856c-4cd5-8765-dfc3fbbbf1ef.png)

Sass compilation error is logged, but does _not_ cause the process to exit on `yarn watch`:
![image](https://user-images.githubusercontent.com/439649/159764663-2538f152-2b9d-4a31-85c0-d4d89ed5da2b.png)

## Documentation

I added a comment to the error handling in question.