### PR TITLE
Add support for renaming processed JS files

### DIFF
--- a/boilerplate/.eslintrc-sample.yml
+++ b/boilerplate/.eslintrc-sample.yml
@@ -20,6 +20,10 @@ globals:
   Waypoint: true
 
 rules:
+  arrow-body-style:
+    - error
+    - as-needed
+    - requireReturnForObjectLiteral: true
   # Override airbnb’s default, since functions are hoisted.
   no-use-before-define:
     - error

--- a/boilerplate/calliope.config-sample.js
+++ b/boilerplate/calliope.config-sample.js
@@ -115,6 +115,19 @@ exports.pipelines = {
     // lint: env.CALLIOPE_LINT_JS === 'true',
 
     /**
+     * rename - Boolean
+     *
+     * Whether compressed JavaScript files should be renamed to add `.min` to
+     * the base filename. This option only takes effect when `compress` is set
+     * to `true` and `bundle` is falsy. It renames processed module files from
+     * `FILENAME.js` to `FILENAME.min.js` before saving them to the destination
+     * directory.
+     *
+     * Uncomment the next line to enable renaming.
+     */
+    // rename: true,
+
+    /**
      * src - String or Array of Strings
      *
      * A value representing one or more JavaScript files to be used as a

--- a/tasks/scripts.js
+++ b/tasks/scripts.js
@@ -6,6 +6,7 @@
 const concat = require('gulp-concat');
 const eslint = require('gulp-eslint-new');
 const gulpIf = require('gulp-if');
+const rename = require('gulp-rename');
 const { src, dest } = require('gulp');
 const terser = require('gulp-terser');
 
@@ -23,6 +24,10 @@ function scripts(bundle) {
     .pipe(gulpIf(pipelineConfig.lint, eslint.format()))
     // Compress/uglify if compression is enabled.
     .pipe(gulpIf(pipelineConfig.compress, terser()))
+    // Rename file if compression and renaming are both enabled.
+    .pipe(gulpIf((pipelineConfig.compress && pipelineConfig.rename), rename((path) => {
+      path.basename += '.min';
+    })))
     // Concatenate script files into a bundle, if a bundle name is set.
     .pipe(gulpIf(pipelineConfig.bundle, concat(bundleName)))
     // Write results to disk.


### PR DESCRIPTION
## Description

This PR adds support for renaming optimized versions of custom JS files to `FILENAME.min.js` before saving them to the destination directory. This is implemented as an opt-in feature. It only affects projects that explicitly set the `scripts.rename` key to `true` in `calliope.config.js`.

## Motivation / Context

Sometimes we want to serve the original files alongside their optimized versions. In such cases, it is necessary to distinguish them via this industry standard.

## Testing Instructions / How This Has Been Tested

See chromatichq/chromatichq-eleventy#273. Once that is approved, this PR should be merged and a new minor release should be published.

## Screenshots

n/a

## Documentation

I added documentation and sample configuration to the `boilerplate/calliope.config-sample.js`, which is copied over to every new Calliope-based project.