### PR TITLE
Make JS/SCSS linting opt-out, instead of opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        node: [12, 14, 16]
+        node: [14, 16, 18]
         platform: [ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2.4.0

--- a/README.md
+++ b/README.md
@@ -142,13 +142,13 @@ The `images` moves image files from the source directory to the destination dire
 
 The `scripts` task handles operations related to JavaScript processing and optimization. It provides linting, uglification/compression (via [`terser`](https://npmjs.com/package/terser)), and concatenation. All of these operations are configurable to some degree.
 
-By default, this task does not lint JS files, but linting can be enabled via an `.env` file. See [Developer Personalization] for details.
+By default, this task lints JS files by default, but linting can be disabled via an `.env` file. See [Developer Personalization] for details.
 
 ### `styles` - Pre-process Stylesheets
 
 The `styles` task generates CSS from your project’s `.scss` files using [`node-sass`](https://npmjs.com/package/node-sass). It includes a few affordances, such as [`gulp-sass-glob`](https://npmjs.com/package/gulp-sass-glob), [`gulp-autoprefixer`](https://www.npmjs.com/package/gulp-autoprefixer), and [`gulp-clean-css`](https://www.npmjs.com/package/gulp-clean-css). This task generates both minified and expanded (i.e. not minified) CSS stylesheets. Minified stylesheets will be named after your SCSS files, and expanded stylesheets will have the suffix `-expanded` attached to the filename. So if your stylesheet is named `main.scss`, Calliope will produce two files: `main.css` and `main-expanded.css`.
 
-By default, this task does not lint SCSS files, but linting can be enabled via an `.env` file. See [Developer Personalization] for details.
+By default, this task lints SCSS files by default, but linting can be disabled via an `.env` file. See [Developer Personalization] for details.
 
 ## Daemons
 
@@ -172,7 +172,7 @@ Calliope works out of the box without much configuration, outside of setting you
 
 # Developer Personalization
 
-In addition to the configuration options available in your project’s `calliope.config.js`, individual developers may modify parts of the tooling behavior according to their personal preferences. Developers may opt into JS and SCSS linting, and modify the reverse proxy’s URL (or opt out of reverse proxying altogether) by creating a `.env` file in their project and setting variables according to their needs. See the [`.env-sample`] file in this project’s repo for reference.
+In addition to the configuration options available in your project’s `calliope.config.js`, individual developers may modify parts of the tooling behavior according to their personal preferences. Developers may opt out of JS and SCSS linting, and modify the reverse proxy’s URL (or opt out of reverse proxying altogether) by creating a `.env` file in their project and setting variables according to their needs. See the [`.env-sample`] file in this project’s repo for reference.
 
 # Customization
 

--- a/boilerplate/.env-sample
+++ b/boilerplate/.env-sample
@@ -3,11 +3,11 @@
 # behaves during development, copy the contents of this file into a `.env` file
 # wherever you installed Calliope (e.g. the theme's folder `web/themes/example`).
 
-# To lint SCSS files during development, uncomment the following line.
-# CALLIOPE_LINT_SCSS=true
+# To skip linting SCSS files during development, uncomment the following line.
+# CALLIOPE_LINT_SCSS=false
 
-# To lint JS files during development, uncomment the following line.
-# CALLIOPE_LINT_JS=true
+# To skip linting JS files during development, uncomment the following line.
+# CALLIOPE_LINT_JS=false
 
 # To have Browsersync reverse proxy your local site, uncomment the following
 # line and set the URL you would like to reverse proxy.

--- a/boilerplate/README-sample.md
+++ b/boilerplate/README-sample.md
@@ -18,7 +18,7 @@ A project based on [`@chromatic/calliope`](https://npmjs.com/package/@chromatic/
     + [Building Project Assets: `yarn build`](#building-project-assets-yarn-build)
     + [Linting SCSS and JS: `yarn lint`](#linting-scss-and-js-yarn-lint)
   * [Development Settings](#development-settings)
-    + [Enable Linting During Development](#enable-linting-during-development)
+    + [Disable Linting During Development](#disable-linting-during-development)
     + [Change Reverse Proxy Target](#change-reverse-proxy-target)
   * [Keeping Documentation Up-to-date](#keeping-documentation-up-to-date)
     + [Updating the Table of Contents](#updating-the-table-of-contents)
@@ -86,13 +86,13 @@ The `.env` file is interpreted as a series of key/value pairs. The format is as 
 ENV_VAR_NAME=some value
 ```
 
-### Enable Linting During Development
+### Disable Linting During Development
 
-If you would like to lint SCSS and JS files during development uncomment the following lines in the `.env` file.
+If you would like to skip linting SCSS and/or JS files during development uncomment the following lines in the `.env` file.
 
 ```
-  # CALLIOPE_LINT_SCSS=true
-  # CALLIOPE_LINT_JS=true
+  # CALLIOPE_LINT_SCSS=false
+  # CALLIOPE_LINT_JS=false
 ```
 
 ### Change Reverse Proxy Target

--- a/boilerplate/calliope.config-sample.js
+++ b/boilerplate/calliope.config-sample.js
@@ -112,7 +112,7 @@ exports.pipelines = {
      * they wish. That said, if your project needs to change this value,
      * uncomment the next line and edit it as needed.
      */
-    // lint: env.CALLIOPE_LINT_JS === 'true',
+    // lint: env.CALLIOPE_LINT_JS !== 'false',
 
     /**
      * rename - Boolean
@@ -165,7 +165,7 @@ exports.pipelines = {
      * they wish. That said, if your project needs to change this value,
      * uncomment the next line and edit it as needed.
      */
-    // lint: env.CALLIOPE_LINT_SCSS === 'true',
+    // lint: env.CALLIOPE_LINT_SCSS !== 'false',
 
     /**
      * src - String or Array of Strings

--- a/config/defaults.js
+++ b/config/defaults.js
@@ -22,7 +22,7 @@ exports.pipelines = {
   scripts: {
     bundle: false,
     compress: true,
-    lint: env.CALLIOPE_LINT_JS === 'true',
+    lint: env.CALLIOPE_LINT_JS !== 'false',
     src: [
       `${paths.SRC}/scripts/**/*.js`,
       `${paths.SRC}/components/**/*.js`,
@@ -31,7 +31,7 @@ exports.pipelines = {
     dest: `${paths.DEST}/scripts`,
   },
   styles: {
-    lint: env.CALLIOPE_LINT_SCSS === 'true',
+    lint: env.CALLIOPE_LINT_SCSS !== 'false',
     src: [
       `${paths.SRC}/styles/**/*.scss`,
     ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@chromatic/calliope",
   "version": "1.4.0",
+  "engines": {
+    "node": ">=14"
+  },
   "description": "An extensible, Gulp-based front-end toolchain designed for quick and fussless setup and maintenance.",
   "main": "calliope.js",
   "scripts": {

--- a/tests/lib/helpers.js
+++ b/tests/lib/helpers.js
@@ -4,7 +4,7 @@
  */
 
 const { execSync } = require('child_process');
-const { cpSync, mkdtempSync, rmdirSync } = require('fs');
+const { cpSync, mkdtempSync, rmSync } = require('fs');
 const { resolve } = require('path');
 const { stdio } = require('./cli');
 
@@ -35,5 +35,5 @@ exports.createTemporaryWorkingDirectory = function createTemporaryWorkingDirecto
 };
 
 exports.deleteTemporaryWorkingDirectory = function deleteTemporaryWorkingDirectory(cwd) {
-  return rmdirSync(cwd, { recursive: true });
+  return rmSync(cwd, { recursive: true });
 };

--- a/tests/styles.spec.js
+++ b/tests/styles.spec.js
@@ -42,4 +42,18 @@ describe('Style tasks', () => {
     const controlFile = readFileSync(resolve(__dirname, 'data/styles/css/basic.css')).toString().replace(/\r\n/g, '\n');
     assert.equal(generatedFile, controlFile);
   });
+
+  it('lints source files during development', () => {
+    let error;
+    // Delete .env file.
+    execSync('rm .env', { cwd, stdio });
+    // Run command.
+    try { execSync(command, { cwd, stdio }); } catch (err) { error = err; }
+    // Assert error due to missing stylelint config file.
+    assert.match(
+      error.message,
+      /No configuration provided/,
+      'Expected an error message for non-existent Stylelint config.',
+    );
+  });
 });

--- a/tests/styles.spec.js
+++ b/tests/styles.spec.js
@@ -24,6 +24,8 @@ describe('Style tasks', () => {
     execSync('yarn add breakpoint-sass', { cwd, stdio });
     mkdirSync(resolve(cwd, 'src'));
     await copyRecursively(basicStylesPath, tmpDirStylesPath);
+    // Create .env file that disables linting.
+    execSync('echo "CALLIOPE_LINT_SCSS=false" > .env', { cwd, stdio });
     // Generate CSS.
     execSync(command, { cwd, stdio });
   });

--- a/tests/styles.spec.js
+++ b/tests/styles.spec.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const { execSync } = require('child_process');
-const { mkdirSync, readFileSync } = require('fs');
+const { mkdirSync, readFileSync, writeFileSync } = require('fs');
 
 const { resolve } = require('path');
 const { cli, stdio } = require('./lib/cli');
@@ -25,7 +25,7 @@ describe('Style tasks', () => {
     mkdirSync(resolve(cwd, 'src'));
     await copyRecursively(basicStylesPath, tmpDirStylesPath);
     // Create .env file that disables linting.
-    execSync('echo "CALLIOPE_LINT_SCSS=false" > .env', { cwd, stdio });
+    writeFileSync(`${cwd}/.env`, 'CALLIOPE_LINT_SCSS=false');
     // Generate CSS.
     execSync(command, { cwd, stdio });
   });


### PR DESCRIPTION
## Description

This PR updates the default configuration of Calliope to make JS/SCSS linting during development opt-out (that is: enabled by default). It also updates the README to reflect this new behavior, as well as the boilerplate README, `.env`, and `calliope.config.js` files. Finally, tests were adjusted to skip linting while processing stylesheets for tests and to add a test that validates that linting is carried out by default.

While running tests, I noticed a deprecation warning for the `fs.rmdirSync` method, so I took this opportunity to switch a helper file to use `fs.rmSync` as recommended.

## Motivation / Context

Wanting JS/SCSS to be linted during development is a more preferable behavior than the alternative (_not_ wanting to lint these files during development), so we should enable linting during development by default, whilst preserving developers’ ability to disable it if desired.

## Testing Instructions / How This Has Been Tested

Tested as part of chromatichq/chromatichq-eleventy#274.

## Screenshots

This screenshot shows the `chromatichq-eleventy` project as it currently exists in chromatichq/chromatichq-eleventy#274 with no `.env` file (`ls .env` fails) and `yarn start` showing errors for offending code in a JS file:

![image](https://user-images.githubusercontent.com/439649/178994505-c993c308-6cfa-4fd1-bd2a-d87b09dbb517.png)

Deprecation warning before the `rmdirSync`-to-`rmSync` change in this PR:
![image](https://user-images.githubusercontent.com/439649/178995583-cc9ac5a4-e295-4766-a223-49f90472616e.png)

No deprecation warning after changes in this PR:
![image](https://user-images.githubusercontent.com/439649/178995847-925e5cdf-2d96-46f9-b13e-d88d1f09127f.png)

## Documentation

The main README, sample README, sample `.env`, and sample `calliope.config.js` files have all been updated to reflect the new behavior.